### PR TITLE
Fix the bug caused by no-block-scope when using nested foreach-stmt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@
 
 - Improve the performance of REPL
 
+### Fixed
+
+- Fix the bug caused by no-block-scope when using nested foreach-stmt, see more in [BUG#40](https://github.com/anole-lang/anole/issues/40)
+
 ## 0.0.21 - 2020/11/24
 
 ### Added

--- a/anole/version.hpp
+++ b/anole/version.hpp
@@ -18,7 +18,7 @@ namespace anole
 */
 struct Version
 {
-    constexpr static auto literal = "HEAD 0.0.22 2020/12/17";
+    constexpr static auto literal = "HEAD 0.0.22 2021/01/05";
 
     constexpr static Size major    = 0;
     constexpr static Size minor    = 0;

--- a/test/sample-tester.hpp
+++ b/test/sample-tester.hpp
@@ -411,4 +411,16 @@ unknown
 )");
 }
 
+TEST(Sample, NestedForeach)
+{
+    ASSERT_EQ(execute(
+// input
+R"(
+foreach [1, 2] as i, foreach [2, 3] as j, { print(i); print(j); }();
+)"),
+
+// output
+R"(12132223)");
+}
+
 #endif


### PR DESCRIPTION
See more in #40 