### PR TITLE
Update the parsing of lambda expressions and block

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,15 +5,18 @@
 ### Added
 
 - Improve declaration with new syntax `@[a, b], c: [1, 2], 3;`, see [FEATURE#50](https://github.com/anole-lang/anole/issues/50)
+- Empty parameters can be omitted. For example, `@: 42;` is a lambda expression
 
 ### Changed
 
 - `return val1, val2;` equals `return [val1, val2]` now
 - Use `=> expr` instead of `} else expr` for the else-expr of match-expr, see [FEATURE#33](https://github.com/anole-lang/anole/issues/33)
+- Returning multi values in lambda-expression must be explicit by writing `[ret1, ..., retn]`, see [FEATURE#54](https://github.com/anole-lang/anole/issues/54)
 
 ### Removed
 
 - Discard feature direct-return-multi-value, see [DISCARD#49](https://github.com/anole-lang/anole/issues/49)
+- Disable using single statement as block by `, stmt`
 
 ## 0.0.22 - 2021/01/24
 

--- a/example/foreach.anole
+++ b/example/foreach.anole
@@ -36,9 +36,15 @@
 }
 
 l: MyList(range(0, 10));
-foreach l as item, print(item);
+foreach l as item {
+    print(item);
+}
 
 l: [1, 2, 3];
-foreach l as i, println(i);
-foreach l as i, i: 10;
+foreach l as i {
+    println(i);
+}
+foreach l as i {
+    i: 10;
+}
 println(l);

--- a/example/math.anole
+++ b/example/math.anole
@@ -27,6 +27,8 @@ println("s");
 
 start: time();
 a: 1;
-while a < 10000000, a: a + 1;
+while a < 10000000 {
+    a: a + 1;
+}
 print(time() - start);
 println("s");

--- a/example/parsec/parsec/parsec.anole
+++ b/example/parsec/parsec/parsec.anole
@@ -12,7 +12,9 @@ infixop +=;
             info.state: true;
             res: rhs(info);
         }
-        if info.state = true, return res;
+        if info.state = true {
+            return res;
+        }
     };
 
 @　(&lhs, &rhs):
@@ -23,7 +25,9 @@ infixop +=;
             info.index: anchor;
         } else {
             @rr: rhs(info);
-            if info.state, return @(f): rr(lr(f));
+            if info.state {
+                return @(f): rr(lr(f));
+            }
         }
     };
 
@@ -44,10 +48,15 @@ infixop +=;
             if (info.index < info.str.size() and info.str[info.index] = str[i]) {
                 i += 1;
                 info.index += 1;
-            } else, break;
+            } else {
+                break;
+            }
         }
-        if i != str.size(), info.state: false;
-        else, return @(f): f(str);
+        if i != str.size() {
+            info.state: false;
+        } else {
+            return @(f): f(str);
+        }
     };
 
 @by(cond):
@@ -58,7 +67,9 @@ infixop +=;
             info.index += 1;
             return @(f): f(res);
         }
-        else, info.state: false;
+        else {
+            info.state: false;
+        }
     };
 
 @epsilon(init):

--- a/test/sample-tester.hpp
+++ b/test/sample-tester.hpp
@@ -84,15 +84,11 @@ TEST(Sample, SimpleIfElseStmt)
 // input
 R"(
 a: 1;
-@foo(x)
-{
+@foo(x) {
     a : 1;
-    if x
-    {
+    if x {
         return a: 2;
-    }
-    else
-    {
+    } else {
         return a: 3;
     };
 };
@@ -240,7 +236,9 @@ R"(
             conts.push(cont);
             try(@(x): x)();
         });
-        if !(e is none), cfun(e);
+        if !(e is none) {
+            cfun(e);
+        }
     }
 
     @try(fun): @(f): f(fun);
@@ -258,7 +256,9 @@ prefixop try;
 infixop catch;
 
 @div(a, b) {
-    if b = 0, throw "err: div 0";
+    if b = 0 {
+        throw "err: div 0";
+    }
     return a / b;
 };
 
@@ -289,18 +289,14 @@ TEST(Sample, CustomOp)
 R"(
 @*=*(lhs, rhs): lhs + rhs;
 
-@*-*(lhs, rhs), return lhs + rhs;
-
 @*^*(lhs, rhs) {
     return lhs + rhs;
 }
 
 infixop 50  *=*;
-infixop 100 *-*;
 infixop 200 *^*;
 
 println(2 * 3 *=* 4 * 5);
-println(2 * 3 *-* 4 * 5);
 println(2 * 3 *^* 4 * 5);
 
 @refof(&var): delay var;
@@ -313,7 +309,6 @@ println(a);)"),
 
 // output
 R"(26
-26
 70
 10
 )");
@@ -418,7 +413,12 @@ TEST(Sample, NestedForeach)
     ASSERT_EQ(execute(
 // input
 R"(
-foreach [1, 2] as i, foreach [2, 3] as j, { print(i); print(j); }();
+foreach [1, 2] as i {
+    foreach [2, 3] as j {
+        print(i);
+        print(j);
+    }
+}
 )"),
 
 // output


### PR DESCRIPTION
Close #54 

### Added

- Empty parameters can be omitted. For example, `@: 42;` is a lambda expression

### Changed

- Returning multi values in lambda-expression must be explicit by writing `[ret1, ..., retn]`, see [FEATURE#54](https://github.com/anole-lang/anole/issues/54)

### Removed

- Disable using single statement as block by `, stmt`